### PR TITLE
Use correct equality unary operator "==" in /usr/sbin bash scripts

### DIFF
--- a/pocketchip-batt/sbin/pocketchip-warn05
+++ b/pocketchip-batt/sbin/pocketchip-warn05
@@ -1,7 +1,7 @@
 #!/bin/bash
 VOLT=""
 
-if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" = "0" ]; then
+if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" == "0" ]; then
 
   while [ -z "$VOLT" ]
   do
@@ -16,7 +16,7 @@ if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/c
     rm $HOME/.pocketchip-batt/warn05
   fi
 
-#elif [ -f $HOME/.pocketchip-batt/warn05 ] && [ $(cat /usr/lib/pocketchip-batt/charging) = "1" ]; then
+#elif [ -f $HOME/.pocketchip-batt/warn05 ] && [ $(cat /usr/lib/pocketchip-batt/charging) == "1" ]; then
 else
 
   while [ -z "$VOLT" ]

--- a/pocketchip-batt/sbin/pocketchip-warn15
+++ b/pocketchip-batt/sbin/pocketchip-warn15
@@ -1,7 +1,7 @@
 #!/bin/bash
 VOLT=""
 
-if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" = "0" ]; then
+if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" == "0" ]; then
 
   while [ -z "$VOLT" ]
   do
@@ -16,7 +16,7 @@ if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/c
   	rm $HOME/.pocketchip-batt/warn*
   fi
 
-#elif [ -f $HOME/.pocketchip-batt/warn15 ] && [ $(cat /usr/lib/pocketchip-batt/charging) = "1" ]; then
+#elif [ -f $HOME/.pocketchip-batt/warn15 ] && [ $(cat /usr/lib/pocketchip-batt/charging) == "1" ]; then
 else
 
   while [ -z "$VOLT" ]


### PR DESCRIPTION
`/usr/sbin/pocketchip-warn05` and `/usr/sbin/pocketchip-warn15` contain the incorrect unary string equality operator and cause the following errors to be logged to the system journal:

```
Jul 05 23:09:00 pocketchip01 pocketchip-warn15[10652]: /usr/sbin/pocketchip-warn15: line 4: [: ==: unary operator expected
Jul 05 23:09:00 pocketchip01 pocketchip-warn15[10652]: rm: cannot remove '/home/chip/.pocketchip-batt/warn*': No such file or directory
Jul 05 23:09:00 pocketchip01 systemd[1]: pocketchip-warn15.service: main process exited, code=exited, status=1/FAILURE
Jul 05 23:09:00 pocketchip01 systemd[1]: Failed to start 15% battery warning polling.
Jul 05 23:09:00 pocketchip01 systemd[1]: Unit pocketchip-warn15.service entered failed state.
Jul 05 23:09:40 pocketchip01 pocketchip-warn05[11095]: /usr/sbin/pocketchip-warn05: line 4: [: ==: unary operator expected
Jul 05 23:09:40 pocketchip01 pocketchip-warn05[11095]: rm: cannot remove '/home/chip/.pocketchip-batt/warn05': No such file or directory
Jul 05 23:09:40 pocketchip01 systemd[1]: pocketchip-warn05.service: main process exited, code=exited, status=1/FAILURE
Jul 05 23:09:40 pocketchip01 systemd[1]: Failed to start 5% battery warning polling.
Jul 05 23:09:40 pocketchip01 systemd[1]: Unit pocketchip-warn05.service entered failed state.
Jul 05 23:10:00 pocketchip01 systemd[1]: pocketchip-warn15.service: main process exited, code=exited, status=1/FAILURE
Jul 05 23:10:00 pocketchip01 systemd[1]: Failed to start 15% battery warning polling.
Jul 05 23:10:00 pocketchip01 systemd[1]: Unit pocketchip-warn15.service entered failed state.

```