### PR TITLE
Add -f option to rm commands to ignore file not found errors

### DIFF
--- a/pocketchip-batt/sbin/pocketchip-warn05
+++ b/pocketchip-batt/sbin/pocketchip-warn05
@@ -1,7 +1,7 @@
 #!/bin/bash
 VOLT=""
 
-if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" == "0" ]; then
+if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" = "0" ]; then
 
   while [ -z "$VOLT" ]
   do
@@ -13,10 +13,10 @@ if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/c
     mkdir -p $HOME/.pocketchip-batt
     touch $HOME/.pocketchip-batt/warn05
   elif [ $(echo " $VOLT < 3400" | bc ) -eq 1 ]; then
-    rm $HOME/.pocketchip-batt/warn05
+    rm -f $HOME/.pocketchip-batt/warn05
   fi
 
-#elif [ -f $HOME/.pocketchip-batt/warn05 ] && [ $(cat /usr/lib/pocketchip-batt/charging) == "1" ]; then
+#elif [ -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" = "1" ]; then
 else
 
   while [ -z "$VOLT" ]
@@ -25,7 +25,7 @@ else
   done
 
   if [ $(echo " $VOLT > 3400" | bc ) -eq 1 ]; then
-    rm $HOME/.pocketchip-batt/warn05
+    rm -f $HOME/.pocketchip-batt/warn05
   fi
 
 

--- a/pocketchip-batt/sbin/pocketchip-warn05
+++ b/pocketchip-batt/sbin/pocketchip-warn05
@@ -1,7 +1,7 @@
 #!/bin/bash
 VOLT=""
 
-if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" = "0" ]; then
+if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" == "0" ]; then
 
   while [ -z "$VOLT" ]
   do
@@ -16,7 +16,7 @@ if [ ! -f $HOME/.pocketchip-batt/warn05 ] && [ "$(cat /usr/lib/pocketchip-batt/c
     rm $HOME/.pocketchip-batt/warn05
   fi
 
-#elif [ -f $HOME/.pocketchip-batt/warn05 ] && [ $(cat /usr/lib/pocketchip-batt/charging) = "1" ]; then
+#elif [ -f $HOME/.pocketchip-batt/warn05 ] && [ $(cat /usr/lib/pocketchip-batt/charging) == "1" ]; then
 else
 
   while [ -z "$VOLT" ]

--- a/pocketchip-batt/sbin/pocketchip-warn15
+++ b/pocketchip-batt/sbin/pocketchip-warn15
@@ -1,7 +1,7 @@
 #!/bin/bash
 VOLT=""
 
-if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" == "0" ]; then
+if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" = "0" ]; then
 
   while [ -z "$VOLT" ]
   do
@@ -13,10 +13,10 @@ if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/c
     mkdir -p $HOME/.pocketchip-batt
     touch $HOME/.pocketchip-batt/warn15
   elif [ $(echo " $VOLT > 3550" | bc) -eq 1 ]; then
-  	rm $HOME/.pocketchip-batt/warn*
+  	rm -f $HOME/.pocketchip-batt/warn*
   fi
 
-#elif [ -f $HOME/.pocketchip-batt/warn15 ] && [ $(cat /usr/lib/pocketchip-batt/charging) == "1" ]; then
+#elif [ -f $HOME/.pocketchip-batt/warn15 ] && [ $(cat /usr/lib/pocketchip-batt/charging) = "1" ]; then
 else
 
   while [ -z "$VOLT" ]
@@ -25,7 +25,7 @@ else
   done
 
   if [ $(echo " $VOLT > 3550" | bc ) -eq 1 ]; then
-    rm $HOME/.pocketchip-batt/warn*
+    rm -f $HOME/.pocketchip-batt/warn*
   fi
 
 fi

--- a/pocketchip-batt/sbin/pocketchip-warn15
+++ b/pocketchip-batt/sbin/pocketchip-warn15
@@ -1,7 +1,7 @@
 #!/bin/bash
 VOLT=""
 
-if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" = "0" ]; then
+if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/charging)" == "0" ]; then
 
   while [ -z "$VOLT" ]
   do
@@ -16,7 +16,7 @@ if [ ! -f $HOME/.pocketchip-batt/warn15 ] && [ "$(cat /usr/lib/pocketchip-batt/c
   	rm $HOME/.pocketchip-batt/warn*
   fi
 
-#elif [ -f $HOME/.pocketchip-batt/warn15 ] && [ $(cat /usr/lib/pocketchip-batt/charging) = "1" ]; then
+#elif [ -f $HOME/.pocketchip-batt/warn15 ] && [ $(cat /usr/lib/pocketchip-batt/charging) == "1" ]; then
 else
 
   while [ -z "$VOLT" ]


### PR DESCRIPTION
This pull request adds the `-f` option to the `rm` commands contained in pocketchip-warn05.service and pocketchip-warn15.service scripts.

Without this change these services fail to complete normally.

See errors logged without this change:

```
chip@pocketchip01:~$ systemctl status pocketchip-warn05
● pocketchip-warn05.service - 5% battery warning polling
   Loaded: loaded (/etc/systemd/system/pocketchip-warn05.service; static)
   Active: activating (start) since Wed 2016-07-06 12:49:41 EDT; 35ms ago
 Main PID: 30711 ((p-warn05))
   CGroup: /system.slice/pocketchip-warn05.service
           └─30711 /bin/bash /usr/sbin/pocketchip-warn05
chip@pocketchip01:~$ systemctl status pocketchip-warn05
● pocketchip-warn05.service - 5% battery warning polling
   Loaded: loaded (/etc/systemd/system/pocketchip-warn05.service; static)
   Active: failed (Result: exit-code) since Wed 2016-07-06 12:49:42 EDT; 3s ago
  Process: 30711 ExecStart=/usr/sbin/pocketchip-warn05 (code=exited, status=1/FAILURE)
 Main PID: 30711 (code=exited, status=1/FAILURE)

Jul 06 12:49:42 pocketchip01 pocketchip-warn05[30711]: rm: cannot remove '/home/chip/.pocketchip-batt/warn05': No...tory
Jul 06 12:49:42 pocketchip01 systemd[1]: pocketchip-warn05.service: main process exited, code=exited, status=1/FAILURE
Jul 06 12:49:42 pocketchip01 systemd[1]: Failed to start 5% battery warning polling.
Jul 06 12:49:42 pocketchip01 systemd[1]: Unit pocketchip-warn05.service entered failed state.
Hint: Some lines were ellipsized, use -l to show in full.
chip@pocketchip01:~$ systemctl status pocketchip-warn15
● pocketchip-warn15.service - 15% battery warning polling
   Loaded: loaded (/etc/systemd/system/pocketchip-warn15.service; static)
   Active: failed (Result: exit-code) since Wed 2016-07-06 12:49:10 EDT; 53s ago
  Process: 30296 ExecStart=/usr/sbin/pocketchip-warn15 (code=exited, status=1/FAILURE)
 Main PID: 30296 (code=exited, status=1/FAILURE)

Jul 06 12:49:10 pocketchip01 pocketchip-warn15[30296]: rm: cannot remove '/home/chip/.pocketchip-batt/warn*': No ...tory
Jul 06 12:49:10 pocketchip01 systemd[1]: pocketchip-warn15.service: main process exited, code=exited, status=1/FAILURE
Jul 06 12:49:10 pocketchip01 systemd[1]: Failed to start 15% battery warning polling.
Jul 06 12:49:10 pocketchip01 systemd[1]: Unit pocketchip-warn15.service entered failed state.
Hint: Some lines were ellipsized, use -l to show in full.

```